### PR TITLE
MKT-KANEO-22: Fix stats service port binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 | Name                | Description                                                                 |
 | ------------------- | --------------------------------------------------------------------------- |
 | `CLOUDFLARE`        | Cloudflare API key                                                          |
+| `PORT`              | Optional HTTP port supplied by the deployment platform; defaults to `1339`  |
 | `STRIPE_SECRET_KEY` | Optional Stripe secret key for `/arr`; omit locally to return empty ARR data |
 
 ## Public endpoints

--- a/src/__tests__/publicController.test.js
+++ b/src/__tests__/publicController.test.js
@@ -1,0 +1,116 @@
+jest.mock('../../dist/helpers/arr', () => ({
+  arr: jest.fn().mockResolvedValue([
+    {
+      annualRecurringRevenue: 1200,
+      monthlyRecurringRevenue: 100,
+    },
+  ]),
+}))
+
+jest.mock('../../dist/helpers/stats', () => ({
+  stats: {
+    borodutch: [1, 2, 3],
+    userCount: {
+      count: 123,
+    },
+  },
+}))
+
+jest.mock('../../dist/helpers/summary', () => ({
+  projectStats: jest.fn().mockImplementation((project) => {
+    if (project === 'randy') {
+      return {
+        randym: {
+          userCount: 10,
+        },
+      }
+    }
+
+    return {
+      [project]: {
+        userCount: 5,
+      },
+    }
+  }),
+  summary: jest.fn().mockReturnValue({
+    userCount: {
+      count: 123,
+    },
+  }),
+}))
+
+jest.mock('../../dist/helpers/userCount', () => ({
+  userCount: {
+    count: 123,
+    history: [['1710000000000', '123']],
+    reachability: {},
+  },
+  userCountReachability: {
+    bots: {},
+    total: {},
+  },
+}))
+
+const PublicController = require('../../dist/controllers/public').default
+
+describe('public controller', () => {
+  let controller
+
+  beforeEach(() => {
+    controller = new PublicController()
+  })
+
+  test('/stats returns the full stats payload', () => {
+    const ctx = {}
+
+    controller.stats(ctx)
+
+    expect(ctx.body).toEqual({
+      borodutch: [1, 2, 3],
+      userCount: {
+        count: 123,
+      },
+    })
+  })
+
+  test('/stats/:project returns the requested project payload', () => {
+    const ctx = {
+      params: {
+        project: 'randy',
+      },
+    }
+
+    controller.projectStats(ctx)
+
+    expect(ctx.body).toEqual({
+      randym: {
+        userCount: 10,
+      },
+    })
+  })
+
+  test('/count returns count and history payload', () => {
+    const ctx = {}
+
+    controller.count(ctx)
+
+    expect(ctx.body).toEqual({
+      count: 123,
+      history: [['1710000000000', '123']],
+      reachability: {},
+    })
+  })
+
+  test('/arr returns ARR data', async () => {
+    const ctx = {}
+
+    await controller.arr(ctx)
+
+    expect(ctx.body).toEqual([
+      {
+        annualRecurringRevenue: 1200,
+        monthlyRecurringRevenue: 100,
+      },
+    ])
+  })
+})

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,12 +10,13 @@ import * as cors from '@koa/cors'
 
 const app = new Koa()
 const router = loadControllers(`${__dirname}/controllers`, { recurse: true })
+const port = Number(process.env.PORT) || 1339
 
 // Run app
 app.use(cors({ origin: '*' }))
 app.use(bodyParser())
 app.use(router.routes())
 app.use(router.allowedMethods())
-app.listen(1339)
+app.listen(port)
 
-console.log('Koa application is up and running on port 1339')
+console.log(`Koa application is up and running on port ${port}`)


### PR DESCRIPTION
## Kaneo
MKT-KANEO-22

## Summary
- bind the Koa app to `process.env.PORT` with the existing `1339` local fallback
- add regression coverage for public `/stats`, `/stats/:project`, `/count`, and `/arr` controller payloads
- document the optional `PORT` deployment variable
- rebase onto current `origin/master` after #39 landed

## Validation
- `yarn test` - passed, 7 suites / 52 tests on 2026-05-21 after rebase
- `git diff --check origin/master...HEAD` - passed
- `PORT=3139 node dist/app.js` with local curl proof:
  - `curl -sSI http://127.0.0.1:3139/count` -> HTTP 200 JSON
  - `curl -sSI http://127.0.0.1:3139/stats` -> HTTP 200 JSON

## Live Endpoint Status
- Reproduced before fix: `https://stats.borodutch.com/count` and `/stats` returned HTTP/2 404 HTML at 2026-05-21 09:35 PDT.
- Rechecked after rebase/push at 2026-05-21 10:08 PDT: both live endpoints still return HTTP/2 404 HTML because this PR has not been merged/deployed yet.
- Local code serves the endpoints correctly; the live failure appears deployment/runtime routing related, most likely the service not binding to the platform-provided port. Live verification still needs to happen after merge/deploy.
