### PR TITLE
Fix Shieldy stats ingestion fallback

### DIFF
--- a/src/__tests__/shieldy.test.js
+++ b/src/__tests__/shieldy.test.js
@@ -39,4 +39,18 @@ describe('Shieldy stats normalization', () => {
     expect(normalized.userCount).toBe(123)
     expect(normalized.userCountSource).toBe('userCount')
   })
+
+  test('keeps explicit zero userCount as valid evidence', () => {
+    const normalized = normalizeShieldyStats({
+      shieldy: {
+        userCount: 0,
+        chatCount: 456,
+        chatDaily: [{ _id: 1, count: 789 }],
+      },
+    })
+
+    expect(normalized.userCount).toBe(0)
+    expect(normalized.userCountSource).toBe('userCount')
+    expect(shieldyUserCount(normalized)).toBe(0)
+  })
 })

--- a/src/__tests__/shieldy.test.js
+++ b/src/__tests__/shieldy.test.js
@@ -1,0 +1,42 @@
+const {
+  normalizeShieldyStats,
+  shieldyUserCount,
+} = require('../../dist/helpers/shieldy')
+
+describe('Shieldy stats normalization', () => {
+  test('keeps current source payload usable without shieldy.userCount', () => {
+    const sourcePayload = {
+      shieldy: {
+        chatDaily: [
+          { _id: null, count: 1 },
+          { _id: 2751, count: 100 },
+        ],
+        chatCount: 779204,
+      },
+    }
+
+    const normalized = normalizeShieldyStats(sourcePayload)
+
+    expect(normalized.chatCount).toBe(779204)
+    expect(normalized.chatDaily).toEqual([
+      { _id: 2751, count: 100 },
+      { _id: null, count: 1 },
+    ])
+    expect(normalized.userCount).toBe(779204)
+    expect(normalized.userCountSource).toBe('chatCount')
+    expect(shieldyUserCount(normalized)).toBe(779204)
+  })
+
+  test('prefers explicit userCount when the source provides it', () => {
+    const normalized = normalizeShieldyStats({
+      shieldy: {
+        userCount: 123,
+        chatCount: 456,
+        chatDaily: [{ _id: 1, count: 789 }],
+      },
+    })
+
+    expect(normalized.userCount).toBe(123)
+    expect(normalized.userCountSource).toBe('userCount')
+  })
+})

--- a/src/controllers/public.ts
+++ b/src/controllers/public.ts
@@ -19,6 +19,7 @@ export default class {
   }
 
   @Get('stats/:project')
+  @Get('stats.:project')
   projectStats(ctx: Context) {
     ctx.body = projectStats(ctx.params.project)
   }

--- a/src/helpers/shieldy.ts
+++ b/src/helpers/shieldy.ts
@@ -21,11 +21,17 @@ function finiteNumber(value: any): number | undefined {
 }
 
 export function shieldyUserCount(stats: ShieldyStats): number | undefined {
-  return (
-    finiteNumber(stats.userCount) ||
-    finiteNumber(stats.chatCount) ||
-    finiteNumber(stats.chatDaily?.[stats.chatDaily.length - 1]?.count)
-  )
+  const explicitUserCount = finiteNumber(stats.userCount)
+  if (explicitUserCount !== undefined) {
+    return explicitUserCount
+  }
+
+  const chatCount = finiteNumber(stats.chatCount)
+  if (chatCount !== undefined) {
+    return chatCount
+  }
+
+  return finiteNumber(stats.chatDaily?.[stats.chatDaily.length - 1]?.count)
 }
 
 export function normalizeShieldyStats(payload: any): ShieldyStats {

--- a/src/helpers/shieldy.ts
+++ b/src/helpers/shieldy.ts
@@ -1,0 +1,53 @@
+export const shieldyStatsUrl = 'http://142.93.135.209:1339/stats'
+
+export type ShieldyDailyPoint = {
+  _id: number | null
+  count: number
+}
+
+export type ShieldyStats = {
+  chatDaily?: ShieldyDailyPoint[]
+  chatCount?: number
+  userCount?: number
+  userCountSource?: 'userCount' | 'chatCount' | 'chatDaily'
+  [key: string]: any
+}
+
+function finiteNumber(value: any): number | undefined {
+  if (typeof value !== 'number' || !isFinite(value)) {
+    return undefined
+  }
+  return value
+}
+
+export function shieldyUserCount(stats: ShieldyStats): number | undefined {
+  return (
+    finiteNumber(stats.userCount) ||
+    finiteNumber(stats.chatCount) ||
+    finiteNumber(stats.chatDaily?.[stats.chatDaily.length - 1]?.count)
+  )
+}
+
+export function normalizeShieldyStats(payload: any): ShieldyStats {
+  const rawStats = payload && payload.shieldy ? payload.shieldy : payload || {}
+  const normalized: ShieldyStats = {
+    ...rawStats,
+  }
+
+  if (Array.isArray(rawStats.chatDaily)) {
+    normalized.chatDaily = rawStats.chatDaily.slice().reverse()
+  }
+
+  const fallbackUserCount = shieldyUserCount(rawStats)
+  if (fallbackUserCount !== undefined) {
+    normalized.userCount = fallbackUserCount
+    normalized.userCountSource =
+      finiteNumber(rawStats.userCount) !== undefined
+        ? 'userCount'
+        : finiteNumber(rawStats.chatCount) !== undefined
+          ? 'chatCount'
+          : 'chatDaily'
+  }
+
+  return normalized
+}

--- a/src/helpers/stats.ts
+++ b/src/helpers/stats.ts
@@ -6,6 +6,7 @@ import { getRandym } from './randym'
 import { getBanofbot } from './banofbot'
 import { getTodorant } from './todorant'
 import { getCheckMyTextBot } from './checkMyTextBot'
+import { normalizeShieldyStats, shieldyStatsUrl } from './shieldy'
 
 export let stats: any = {}
 
@@ -15,12 +16,7 @@ async function updateStats() {
 
   // Shieldy
   try {
-    const shieldyStats = (await axios('http://142.93.135.209:1339/stats')).data
-      .shieldy
-    stats.shieldy = shieldyStats
-    if (stats.shieldy.chatDaily) {
-      stats.shieldy.chatDaily = stats.shieldy.chatDaily.reverse()
-    }
+    stats.shieldy = normalizeShieldyStats((await axios(shieldyStatsUrl)).data)
   } catch (err) {
     console.log(err)
   }

--- a/src/helpers/userCount.ts
+++ b/src/helpers/userCount.ts
@@ -6,6 +6,11 @@ import {
 } from './optimizedGetBotUsers'
 import { emptyReachabilityMetrics } from './reachability'
 import { appendFileSync, mkdirSync, readFileSync } from 'fs'
+import {
+  normalizeShieldyStats,
+  shieldyStatsUrl,
+  shieldyUserCount,
+} from './shieldy'
 const Telegraf = require('telegraf')
 
 const userCountPath = `${__dirname}/../../usercount/usercount.txt`
@@ -90,12 +95,17 @@ export async function runCollection(): Promise<{
 
   // Shieldy
   console.log('+ getting shieldy stats')
-  const shieldyStats = (await axios('http://142.93.135.209:1339/stats')).data
-    .shieldy
-  const shieldyUsers = shieldyStats.userCount
-  legacyResult.push(shieldyUsers)
+  const shieldyStats = normalizeShieldyStats(
+    (await axios(shieldyStatsUrl)).data
+  )
+  const shieldyUsers = shieldyUserCount(shieldyStats)
+  if (shieldyUsers === undefined) {
+    console.log('+ shieldy user count unavailable; skipping shieldy contribution')
+  } else {
+    legacyResult.push(shieldyUsers)
+  }
   console.log('+ result ' + JSON.stringify(legacyResult))
-  userCountSeparate.shieldy = shieldyUsers
+  userCountSeparate.shieldy = shieldyUsers || 0
 
   // Golden borodutch
   console.log('+ getting golden borodutch stats')


### PR DESCRIPTION
## Summary
- Normalize Shieldy stats through a shared helper so the current source payload keeps `chatDaily` and `chatCount` usable.
- Fall back from missing `shieldy.userCount` to `chatCount` for the daily user-count contribution and record `userCountSource` evidence.
- Add dotted project stats routing for `/stats.shieldy` alongside `/stats/shieldy`.

## Validation
- `yarn test` - passed, 6 suites / 47 tests.
- Live Shieldy source proof: `chatCount=779204`, `userCount=779204`, `userCountSource=chatCount`, `chatDailyLength=2753`.

## Manual QA
Manual QA: blocked for public live endpoints until MKT-KANEO-22 restores the public stats/count routing. Once routing is healthy, verify `/stats.shieldy` and `/stats/shieldy` return a Shieldy object with usable `chatDaily`, `chatCount`, and `userCountSource: "chatCount"`.
