### PR TITLE
MKT-25: derive summary project counts

### DIFF
--- a/src/__tests__/summary.test.js
+++ b/src/__tests__/summary.test.js
@@ -1,0 +1,102 @@
+const mockStats = {}
+
+jest.mock('../../dist/helpers/stats', () => ({
+  stats: mockStats,
+}))
+
+const { deriveProjectCounts, summary } = require('../../dist/helpers/summary')
+
+function resetStats(value) {
+  for (const key of Object.keys(mockStats)) {
+    delete mockStats[key]
+  }
+  Object.assign(mockStats, value)
+}
+
+describe('summary stats', () => {
+  beforeEach(() => {
+    resetStats({})
+  })
+
+  test('derives lightweight project counts when cached per-project counts are empty', () => {
+    resetStats({
+      shieldy: {
+        chatDaily: [{ _id: 1, count: 2 }],
+        chatCount: 780587,
+        userCount: 60472766,
+      },
+      voicy: {
+        stats: {
+          chatCount: 4104363,
+          messageStats: [{ date: '2026-05-27', count: 10 }],
+        },
+      },
+      banofbot: {
+        userCount: 200000,
+        chatCount: 326449,
+        requestDaily: [{ _id: 1, count: 2 }],
+      },
+      temply: {
+        userCount: 12046,
+        userDaily: [{ _id: 1, count: 2 }],
+      },
+      userCount: {
+        count: 110924319,
+        history: [['1776176459819', '110924319']],
+      },
+      userCountSeparate: {},
+    })
+
+    const data = summary()
+
+    expect(data.projectCounts.shieldy).toEqual({
+      count: 60472766,
+      label: 'users',
+      source: 'shieldy.userCount',
+    })
+    expect(data.projectCounts.voicy).toEqual({
+      count: 4104363,
+      label: 'chats',
+      source: 'voicy.stats.chatCount',
+    })
+    expect(data.projectCounts.banofbot).toEqual({
+      count: 200000,
+      label: 'users',
+      source: 'banofbot.userCount',
+    })
+    expect(data.projectCounts.temply).toEqual({
+      count: 12046,
+      label: 'users',
+      source: 'temply.userCount',
+    })
+    expect(data.userCountSeparate).toEqual({
+      shieldy: 60472766,
+      banofbot: 200000,
+      temply: 12046,
+    })
+    expect(data.shieldy.chatDaily).toBeUndefined()
+    expect(data.userCount.history).toBeUndefined()
+  })
+
+  test('prefers a positive cached user count over scalar summary fallbacks', () => {
+    resetStats({
+      voicy: {
+        stats: {
+          chatCount: 4104363,
+        },
+      },
+      userCountSeparate: {
+        voicy: 987654,
+      },
+    })
+
+    expect(deriveProjectCounts(mockStats).voicy).toEqual({
+      count: 987654,
+      label: 'users',
+      source: 'userCountSeparate',
+    })
+    expect(summary().userCountSeparate).toEqual({
+      voicy: 987654,
+    })
+  })
+})

--- a/src/helpers/summary.ts
+++ b/src/helpers/summary.ts
@@ -1,5 +1,106 @@
 import { stats } from './stats'
 
+type CountLabel = 'users' | 'chats'
+
+export type ProjectCountSummary = {
+  count: number
+  label: CountLabel
+  source: string
+}
+
+function finitePositiveNumber(value: any): number | undefined {
+  if (typeof value !== 'number' || !isFinite(value) || value <= 0) {
+    return undefined
+  }
+  return value
+}
+
+function count(
+  value: any,
+  label: CountLabel,
+  source: string
+): ProjectCountSummary | undefined {
+  const parsed = finitePositiveNumber(value)
+  if (parsed === undefined) {
+    return undefined
+  }
+
+  return { count: parsed, label, source }
+}
+
+function firstCount(
+  ...counts: Array<ProjectCountSummary | undefined>
+): ProjectCountSummary | undefined {
+  return counts.find(Boolean)
+}
+
+export function deriveProjectCounts(source: any): {
+  [project: string]: ProjectCountSummary
+} {
+  const result: { [project: string]: ProjectCountSummary } = {}
+
+  const userCountSeparate = source.userCountSeparate || {}
+  for (const key of Object.keys(userCountSeparate)) {
+    const projectCount = count(
+      userCountSeparate[key],
+      'users',
+      'userCountSeparate'
+    )
+    if (projectCount) {
+      result[key] = projectCount
+    }
+  }
+
+  const fallbacks: { [project: string]: ProjectCountSummary | undefined } = {
+    shieldy: firstCount(
+      count(source.shieldy?.userCount, 'users', 'shieldy.userCount'),
+      count(source.shieldy?.chatCount, 'chats', 'shieldy.chatCount')
+    ),
+    voicy: count(
+      source.voicy?.stats?.chatCount,
+      'chats',
+      'voicy.stats.chatCount'
+    ),
+    banofbot: firstCount(
+      count(source.banofbot?.userCount, 'users', 'banofbot.userCount'),
+      count(source.banofbot?.chatCount, 'chats', 'banofbot.chatCount')
+    ),
+    randy: count(source.randym?.chatCount, 'chats', 'randym.chatCount'),
+    todorant: count(
+      source.todorant?.db?.userCount,
+      'users',
+      'todorant.db.userCount'
+    ),
+    temply: count(source.temply?.userCount, 'users', 'temply.userCount'),
+    checkMyTextBot: count(
+      source.checkMyTextBot?.userCount,
+      'users',
+      'checkMyTextBot.userCount'
+    ),
+  }
+
+  for (const key of Object.keys(fallbacks)) {
+    if (!result[key] && fallbacks[key]) {
+      result[key] = fallbacks[key] as ProjectCountSummary
+    }
+  }
+
+  return result
+}
+
+function deriveUserCountSeparate(source: any): { [project: string]: number } {
+  const result: { [project: string]: number } = {}
+  const projectCounts = deriveProjectCounts(source)
+
+  for (const key of Object.keys(projectCounts)) {
+    if (projectCounts[key].label === 'users') {
+      result[key] = projectCounts[key].count
+    }
+  }
+
+  return result
+}
+
 function trimHeavyData(value: any): any {
   if (Array.isArray(value)) {
     return undefined
@@ -19,7 +120,15 @@ function trimHeavyData(value: any): any {
 }
 
 export function summary() {
-  return trimHeavyData(stats)
+  const trimmed = trimHeavyData(stats)
+  const projectCounts = deriveProjectCounts(stats)
+  const userCountSeparate = deriveUserCountSeparate(stats)
+
+  return {
+    ...trimmed,
+    projectCounts,
+    userCountSeparate,
+  }
 }
 
 const projectStatsKeys: { [project: string]: string[] } = {


### PR DESCRIPTION
## Summary
- Add derived lightweight projectCounts to /summary so borodutch.com can show card subtitles after a stats-server restart even when cached userCountSeparate is empty.
- Rehydrate userCountSeparate in the summary response from available scalar stats where the value is a real user count.
- Preserve Shieldy explicit userCount as the preferred source, with chatCount only as the fallback project summary label.
- Add regression coverage for empty cached counts and trimmed summary payloads.

## Validation
- yarn install --frozen-lockfile
- yarn test --runInBand
- yarn build-ts

Related: MKT-25. Companion frontend PR is in backmeupplz/borodutch.
